### PR TITLE
P81-113790 chore(security): pin 3rd party actions to SHA commits [skip actions]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: 1.16
 
@@ -24,13 +24,13 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@v2.1.0
+        uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588 # v2.1.0
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b # v2
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     
     - name: Setup
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
     


### PR DESCRIPTION
## Summary
- Pin 3rd party GitHub Actions to SHA commit hashes for supply-chain security
- Set internal actions (`perimeter-81/actions/actions/...`) to `@v1` with `# zizmor: ignore[unpinned-uses]`
- Prevents supply-chain attacks via tag mutation

Part of epic [P81-113387](https://perimeter81.atlassian.net/browse/P81-113387)

## Review guidelines

### 1. Internal actions must be pinned to `@v1`

```yaml
# ✅ Correct
uses: perimeter-81/actions/actions/aws/assume_role_v2@v1 # zizmor: ignore[unpinned-uses]

# ❌ Wrong — points to @main or feature branch
uses: perimeter-81/actions/actions/aws/assume_role@main # zizmor: ignore[unpinned-uses]
```

### 2. 3rd party actions must be pinned to full SHA with version comment

```yaml
# ✅ Correct
uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

# ❌ Wrong — version tag instead of SHA
uses: actions/checkout@v4

# ❌ Wrong — SHA without version comment
uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
```

### Quick validation
```bash
# 3rd party still using version tags
grep -rn "uses:" .github/workflows/ | grep -v "perimeter-81/" | grep "@v"

# 3rd party missing version comment
grep -rn "uses:" .github/workflows/ | grep "@[a-f0-9]\{40\}" | grep -v "#"

# Internal actions not pinned to @v1
grep -rn "uses:.*perimeter-81/actions/actions/" .github/workflows/ | grep -v "@v1"
```

## Test plan
- [ ] Verify workflow files have correct SHA pins with version comments
- [ ] Verify internal actions point to `@v1` with zizmor comment

[P81-113387]: https://perimeter81.atlassian.net/browse/P81-113387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ