### PR TITLE
[skip actions] P81-120677 Migrate to self-hosted runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
       - 'v*'
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ACTIONS_RUNNER }}
     steps:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2


### PR DESCRIPTION
Jira: https://perimeter81.atlassian.net/browse/P81-120677

## Changes

Migrated workflow `runs-on` values to `${{ vars.ACTIONS_RUNNER }}`.

Runner selected because: repository does not require Docker-in-Docker.

### Modified workflow files

- `.github/workflows/release.yaml`

---
Co-authored-by: Claude (claude-sonnet-4-6)