### PR TITLE
Migrate Windows runners to CodeBuild self-hosted (P81-121883)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,6 @@ jobs:
   test:
 
     strategy:
-      fail-fast: false
       matrix:
         go-version: [1.16.x]
         os: ["${{ vars.ACTIONS_RUNNER }}", macos-latest, windows-latest]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,13 @@ jobs:
       matrix:
         go-version: [1.16.x]
         os: ["${{ vars.ACTIONS_RUNNER }}", macos-latest, windows-latest]
+        include:
+          - os: windows-latest
+            runner:
+              - codebuild-devops-windows-large-runner-${{ github.run_id }}-${{ github.run_attempt }}
+              - buildspec-override:true
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
 
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ jobs:
   test:
 
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.16.x]
         os: ["${{ vars.ACTIONS_RUNNER }}", macos-latest, windows-latest]


### PR DESCRIPTION
**Jira link:**
---
https://perimeter81.atlassian.net/browse/P81-121883

Technical problem description
---
The matrix-driven `test` job in `test.yaml` still uses GitHub-hosted
`windows-latest` for the Windows matrix entry. The org is migrating all
Windows workflows to AWS CodeBuild reserved-capacity self-hosted fleets
(`codebuild-devops-windows-large-runner-*`) backed by a custom Windows AMI.

What fixed/changed:
---

* `.github/workflows/test.yaml` — added per-matrix-entry `runner` field; the `windows-latest` entry now resolves to codebuild-devops-windows-large-runner. Non-Windows matrix entries unchanged.
* Added `buildspec-override:true` so CodeBuild PowerShell phase logs surface in the GitHub Actions job UI.