### PR TITLE
bump 3rd party actions to major version [P81-126579]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ${{ vars.ACTIONS_RUNNER }}
     steps:
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.16
 
@@ -30,7 +30,7 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b # v2
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     
     - name: Setup
-      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ matrix.go-version }}
     


### PR DESCRIPTION
**Jira link:**
---
https://perimeter81.atlassian.net/browse/P81-126579

Technical problem description
---
GitHub Actions periodically deprecates older Node.js runtimes (node12, node16, node20) used by third-party actions. Running workflows that reference outdated action versions produces deprecation warnings and will eventually fail once those runtimes are removed. Additionally, outdated actions may miss security patches and bug fixes available in newer major versions.

What fixed/changed:
---

* Bumped all outdated third-party GitHub Actions in this repo to their latest major version.
* All updated `uses:` lines are SHA-pinned to a full 40-character commit SHA with a `# v<version>` comment, following the org-wide pinning policy.
* Generated by `actions-up --style sha --mode major` via the automated update workflow.