### PR TITLE
P81-121883: migrate Windows test to CodeBuild

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,35 +2,47 @@ name: test
 
 on: [push]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   test:
 
     strategy:
       matrix:
         go-version: [1.16.x]
-        os: ["${{ vars.ACTIONS_RUNNER }}", macos-latest, windows-latest]
+        include:
+          - os: linux
+            runs-on: ${{ vars.ACTIONS_RUNNER }}
+          - os: macos
+            runs-on: macos-latest
+          - os: windows
+            runs-on:
+              - codebuild-devops-windows-large-runner-${{ github.run_id }}-${{ github.run_attempt }}
+              - buildspec-override:true
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
-    
+
     - name: Setup
       uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
-    
+
     - name: Dependencies
       run: |
         go version
         go get -u golang.org/x/lint/golint
-        
+
     - name: Build
       run: make build
-      
+
     - name: Code Style
       run: make lint
-    
+
     - name: Test PR
       if: github.ref != 'refs/heads/master'
       run: make test


### PR DESCRIPTION
**Jira link:** 
---
https://perimeter81.atlassian.net/browse/P81-121883

Technical problem description
---
The test matrix in our `packer-plugin-upcloud` fork uses a `windows-latest` (GH-hosted) entry. Org-wide effort (P81-121883) is to move all Windows CI off GH-hosted runners onto CodeBuild's self-hosted reserved fleet. The file is perimeter-81-customized (uses `vars.ACTIONS_RUNNER`), so this migration does not diverge us from anything we previously shared with upstream.

What fixed/changed:
---

* `.github/workflows/test.yaml::test` — restructured matrix to `include:` form so `runs-on` can be a YAML list. Linux entry kept on `vars.ACTIONS_RUNNER`, macOS kept on `macos-latest`. Windows entry now targets `codebuild-devops-windows-large-runner-${{ github.run_id }}-${{ github.run_attempt }}` + `buildspec-override:true`.
* Top-level `runs-on:` switched to `${{ matrix.runs-on }}`; `go-version` matrix axis preserved.
* Added workflow-scope `permissions: id-token: write, contents: read` (was missing).
* No workflow steps reference `matrix.os`, so renaming the matrix.os values from runner-labels to OS-family names is non-breaking.

ToDo
---
* None.
